### PR TITLE
make append CFLAGS happened

### DIFF
--- a/portsf/Makefile
+++ b/portsf/Makefile
@@ -3,7 +3,7 @@ POBJS = ieee80.o portsf.o
 
 # CFLAGS = -I ../include -D_DEBUG -g
 # on strange 64 bit platforms must define CPLONG64
-CFLAGS = -Dunix -O2 -I ../include
+override CFLAGS += -Dunix -O2 -I ../include
 
 CC=gcc
 


### PR DESCRIPTION
In order to append the CFLAGS to portsf source files while using `make` command, I modified CLAGS variable in Makefile

here is my folder tree as I used portsf lib, so I can pass my won CFLAGS to portsf
```
.
├── Makefile
├── portsf
│   ├── README.md
│   ├── include
│   │   └── portsf.h
│   └── portsf
│       ├── Makefile
│       ├── ieee80.c
│       ├── ieee80.h
│       ├── libportsf.a
│       └── portsf.c
└── test.c
```